### PR TITLE
[ENH] Add fn kwargs and tests for sklearn metrics

### DIFF
--- a/mindsdb_evaluator/accuracy/classification.py
+++ b/mindsdb_evaluator/accuracy/classification.py
@@ -1,7 +1,7 @@
 from sklearn.metrics import f1_score, top_k_accuracy_score
 
 
-def evaluate_multilabel_accuracy(y_true, y_pred, **kwargs):
+def evaluate_multilabel_accuracy(y_true, y_pred):
     """
     Evaluates accuracy for multilabel/tag prediction.
 
@@ -11,12 +11,11 @@ def evaluate_multilabel_accuracy(y_true, y_pred, **kwargs):
     return f1_score(y_true, pred_values, average='weighted')
 
 
-def evaluate_top_k_accuracy(y_true, y_pred, **kwargs):
+def evaluate_top_k_accuracy(y_true, y_pred, k: int = 2):
     """
     Evaluates the number of times where the correct label is among the top k labels
 
     :return: top k accuracy score of y_pred and ground truths.
     """
     pred_values = y_pred['prediction']
-    k = kwargs['k'] if 'k' in kwargs else 2
     return top_k_accuracy_score(y_true, pred_values, k=k)

--- a/mindsdb_evaluator/accuracy/general.py
+++ b/mindsdb_evaluator/accuracy/general.py
@@ -1,6 +1,7 @@
 import importlib
 from typing import List, Dict, Optional
 
+import numpy as np
 import pandas as pd
 
 from mindsdb_evaluator.accuracy.forecasting import \
@@ -10,12 +11,17 @@ from mindsdb_evaluator.accuracy.forecasting import \
     complementary_smape_array_accuracy
 
 
+SCORE_TYPES = (float, np.float16, np.float32, np.float64, np.float128,
+               int, np.int8, np.int16, np.int32, np.int64)
+
+
 def evaluate_accuracy(data: pd.DataFrame,
                       predictions: pd.Series,
                       accuracy_function: str,
                       target: Optional[str] = None,
                       ts_analysis: Optional[dict] = {},
-                      n_decimals: Optional[int] = 3) -> float:
+                      n_decimals: Optional[int] = 3,
+                      fn_kwargs: Optional[dict] = {}) -> float:
     """
     Dispatcher for accuracy evaluation.
 
@@ -25,6 +31,7 @@ def evaluate_accuracy(data: pd.DataFrame,
     :param accuracy_function: either a metric from the `accuracy` module or `scikit-learn.metric`.
     :param ts_analysis: `lightwood.data.timeseries_analyzer` output, used to compute time series task accuracy.
     :param n_decimals: used to round accuracies.
+    :param fn_kwargs: additional arguments to be passed to the accuracy function.
     
     :return: accuracy score, given input data and model predictions.
     """  # noqa
@@ -53,7 +60,9 @@ def evaluate_accuracy(data: pd.DataFrame,
         else:
             raise Exception(f"Could not retrieve accuracy function: {accuracy_function}")
 
-        score = acc_fn(y_true, y_pred, data=data[cols], ts_analysis=ts_analysis)
+        fn_kwargs['data'] = data[cols]
+        fn_kwargs['ts_analysis'] = ts_analysis
+        score = acc_fn(y_true, y_pred, **fn_kwargs)
     else:
         y_true = data[target].tolist()
         y_pred = list(predictions)
@@ -64,11 +73,14 @@ def evaluate_accuracy(data: pd.DataFrame,
             accuracy_function = getattr(importlib.import_module('sklearn.metrics'), accuracy_function)
 
         try:
-            score = accuracy_function(y_true, y_pred)
+            score = accuracy_function(y_true, y_pred, **fn_kwargs)
+            assert type(score) in SCORE_TYPES, f"Accuracy function `{accuracy_function.__name__}` returned invalid type {type(score)}"  # noqa
         except ValueError as e:
             if 'mix of label input' in str(e).lower():
+                # mixed types, try to convert to string  # TODO: should this be a burden on the evaluator?
                 score = accuracy_function([str(y) for y in y_true],
-                                          [str(y) for y in y_pred])
+                                          [str(y) for y in y_pred],
+                                          **fn_kwargs)
             else:
                 raise e
 

--- a/mindsdb_evaluator/accuracy/regression.py
+++ b/mindsdb_evaluator/accuracy/regression.py
@@ -5,7 +5,6 @@ from sklearn.metrics import r2_score
 def evaluate_regression_accuracy(
         y_true,
         y_pred,
-        **kwargs
 ):
     """
     Evaluates accuracy for regression tasks.

--- a/mindsdb_evaluator/helpers/general.py
+++ b/mindsdb_evaluator/helpers/general.py
@@ -1,0 +1,9 @@
+import inspect
+from typing import Dict, Callable
+
+def filter_fn_args(fn: Callable, args: Dict) -> Dict:
+    filtered = {}
+    for k, v in args.items():
+        if k in inspect.signature(fn).parameters:
+            filtered[k] = v
+    return filtered

--- a/mindsdb_evaluator/helpers/general.py
+++ b/mindsdb_evaluator/helpers/general.py
@@ -1,6 +1,7 @@
 import inspect
 from typing import Dict, Callable
 
+
 def filter_fn_args(fn: Callable, args: Dict) -> Dict:
     filtered = {}
     for k, v in args.items():

--- a/tests/test_sklearn_metrics.py
+++ b/tests/test_sklearn_metrics.py
@@ -1,0 +1,66 @@
+import unittest
+import pandas as pd
+from mindsdb_evaluator import evaluate_accuracy
+
+
+class TestSklearnMetrics(unittest.TestCase):
+    def setUp(self):
+        self.data = pd.DataFrame.from_records({'target': [0, 1, 2, 0, 1, 2]})
+        self.pred = pd.Series([0, 2, 1, 0, 0, 1])
+        self.target = 'target'
+
+    # PRECISION SCORE #
+    def test_sklearn_precision_score_macro(self):
+        acc = evaluate_accuracy(self.data, self.pred, 'precision_score', self.target,
+                                fn_kwargs={'average': 'macro'})
+        self.assertAlmostEqual(acc, 0.222)
+
+    def test_sklearn_precision_score_micro(self):
+        acc = evaluate_accuracy(self.data, self.pred, 'precision_score', self.target,
+                                fn_kwargs={'average': 'micro'})
+        self.assertAlmostEqual(acc, 0.333)
+
+    def test_sklearn_precision_score_weighted(self):
+        acc = evaluate_accuracy(self.data, self.pred, 'precision_score', self.target,
+                                fn_kwargs={'average': 'weighted'})
+        self.assertAlmostEqual(acc, 0.222)
+
+    def test_sklearn_precision_score_none(self):
+        expected_err_str = "Accuracy function `precision_score` returned invalid type *"
+        with self.assertRaisesRegex(AssertionError, expected_err_str):
+            evaluate_accuracy(self.data, self.pred, 'precision_score', self.target,
+                              fn_kwargs={'average': None})
+
+    def test_sklearn_precision_score_binary_for_multiclass(self):
+        expected_err_str = "Target is multiclass but average='binary'.*"
+        with self.assertRaisesRegex(ValueError, expected_err_str):
+            evaluate_accuracy(self.data, self.pred, 'precision_score', self.target,
+                              fn_kwargs={'average': 'binary'})
+
+    # RECALL SCORE #
+    def test_sklearn_recall_score_macro(self):
+        acc = evaluate_accuracy(self.data, self.pred, 'recall_score', self.target,
+                                fn_kwargs={'average': 'macro'})
+        self.assertAlmostEqual(acc, 0.333)
+
+    def test_sklearn_recall_score_micro(self):
+        acc = evaluate_accuracy(self.data, self.pred, 'recall_score', self.target,
+                                fn_kwargs={'average': 'micro'})
+        self.assertAlmostEqual(acc, 0.333)
+
+    def test_sklearn_recall_score_weighted(self):
+        acc = evaluate_accuracy(self.data, self.pred, 'recall_score', self.target,
+                                fn_kwargs={'average': 'weighted'})
+        self.assertAlmostEqual(acc, 0.333)
+
+    def test_sklearn_recall_score_none(self):
+        expected_err_str = "Accuracy function `recall_score` returned invalid type *"
+        with self.assertRaisesRegex(AssertionError, expected_err_str):
+            evaluate_accuracy(self.data, self.pred, 'recall_score', self.target,
+                              fn_kwargs={'average': None})
+
+    def test_sklearn_recall_score_binary_for_multiclass(self):
+        expected_err_str = "Target is multiclass but average='binary'.*"
+        with self.assertRaisesRegex(ValueError, expected_err_str):
+            evaluate_accuracy(self.data, self.pred, 'recall_score', self.target,
+                              fn_kwargs={'average': 'binary'})


### PR DESCRIPTION
This PR:
- cleans up some signatures to avoid unsupported arguments making their way through
- changes main entry point so that keyword arguments can be passed to any accuracy metric in a general way. This is useful to control behavior of external functions like those found in `scikit-learn.metrics`.
- adds tests to check that `sklearn.metrics` can be customized through keyword arguments correctly