### PR TITLE
[ENH] Pass top level args in evaluate_accuracies

### DIFF
--- a/mindsdb_evaluator/accuracy/general.py
+++ b/mindsdb_evaluator/accuracy/general.py
@@ -1,10 +1,10 @@
 import importlib
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Union
 
 import numpy as np
 import pandas as pd
 
-from mindsdb_evaluator.helpers.general import filter_fn_args
+from mindsdb_evaluator.helpers.general import Module, filter_fn_args
 from mindsdb_evaluator.accuracy.forecasting import \
     evaluate_array_accuracy, \
     evaluate_num_array_accuracy, \
@@ -94,17 +94,23 @@ def evaluate_accuracy(data: pd.DataFrame,
 def evaluate_accuracies(data: pd.DataFrame,
                         predictions: pd.Series,
                         target: str,
-                        accuracy_functions: List[str],
+                        accuracy_functions: List[Union[str, Module]],
                         ts_analysis: Optional[dict] = {},
                         n_decimals: Optional[int] = 3) -> Dict[str, float]:
     score_dict = {}
     for accuracy_function in accuracy_functions:
+        fn_kwargs = {}
+        if isinstance(accuracy_function, Module):
+            fn_kwargs = accuracy_function['args']
+            accuracy_function = accuracy_function['module']
         score = evaluate_accuracy(data,
                                   predictions,
                                   accuracy_function,
                                   target=target,
                                   ts_analysis=ts_analysis,
-                                  n_decimals=n_decimals)
+                                  n_decimals=n_decimals,
+                                  fn_kwargs=fn_kwargs,
+                                  )
         score_dict[accuracy_function] = score
 
     return score_dict

--- a/mindsdb_evaluator/accuracy/general.py
+++ b/mindsdb_evaluator/accuracy/general.py
@@ -100,7 +100,7 @@ def evaluate_accuracies(data: pd.DataFrame,
     score_dict = {}
     for accuracy_function in accuracy_functions:
         fn_kwargs = {}
-        if isinstance(accuracy_function, Module):
+        if not isinstance(accuracy_function, str):
             fn_kwargs = accuracy_function['args']
             accuracy_function = accuracy_function['module']
         score = evaluate_accuracy(data,

--- a/mindsdb_evaluator/helpers/general.py
+++ b/mindsdb_evaluator/helpers/general.py
@@ -1,5 +1,17 @@
 import inspect
-from typing import Dict, Callable
+from typing import Dict, Callable, TypedDict
+
+
+class Module(TypedDict):
+    """
+    Modules are blocks of code, representing either object instantiations or function calls. 
+    See the mindsdb/lightwood/api/types:Module equivalent for more details.
+
+    :param module: Name of the module (function or class name)
+    :param args: Argument to pass to the function or constructor
+    """ # noqa
+    module: str
+    args: Dict[str, str]
 
 
 def filter_fn_args(fn: Callable, args: Dict) -> Dict:

--- a/tests/test_sklearn_metrics.py
+++ b/tests/test_sklearn_metrics.py
@@ -1,6 +1,6 @@
 import unittest
 import pandas as pd
-from mindsdb_evaluator import evaluate_accuracy
+from mindsdb_evaluator import evaluate_accuracy, evaluate_accuracies
 
 
 class TestSklearnMetrics(unittest.TestCase):
@@ -64,3 +64,10 @@ class TestSklearnMetrics(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, expected_err_str):
             evaluate_accuracy(self.data, self.pred, 'recall_score', self.target,
                               fn_kwargs={'average': 'binary'})
+
+    def test_sklearn_wrapped_with_args(self):
+        acc_fn = 'recall_score'
+        acc_fns = [{"module": acc_fn, "args": {'average': 'macro'}}]
+        acc = evaluate_accuracies(self.data, self.pred, self.target, acc_fns)
+        print(acc)
+        self.assertAlmostEqual(acc[acc_fn], 0.333)


### PR DESCRIPTION
User can now specify `Module`s (a specific type of `TypedDict`s) to provide arguments for each function in the list.