### PR TITLE
[fix] Better sklearn imports

### DIFF
--- a/mindsdb_evaluator/__init__.py
+++ b/mindsdb_evaluator/__init__.py
@@ -1,7 +1,7 @@
 from mindsdb_evaluator.accuracy import *  # noqa
 from mindsdb_evaluator.calibration import *  # noqa
 
-__version__ = '0.0.11'
+__version__ = '0.0.12'
 name = "mindsdb_evaluator"
 
 __all__ = ['name', '__version__']

--- a/mindsdb_evaluator/accuracy/__init__.py
+++ b/mindsdb_evaluator/accuracy/__init__.py
@@ -14,11 +14,10 @@ from mindsdb_evaluator.accuracy.forecasting import \
 
 __sklearn_accs__ = [acc for acc in __sklearn_accs__ if acc[0].lower() == acc[0]]
 
-# TODO: enable custom arg passing for sklearn metrics, and to_ordinal (stateful?)
 sk_metrics = importlib.import_module('sklearn.metrics')
 for skacc in __sklearn_accs__:
     globals()[skacc] = getattr(sk_metrics, skacc)
 
 __all__ = ['evaluate_accuracy', 'evaluate_accuracies', 'evaluate_regression_accuracy', 'evaluate_multilabel_accuracy',
            'evaluate_top_k_accuracy', 'evaluate_array_accuracy', 'evaluate_num_array_accuracy',
-           'evaluate_cat_array_accuracy', 'complementary_smape_array_accuracy'] + __sklearn_accs__  # noqa
+           'evaluate_cat_array_accuracy', 'complementary_smape_array_accuracy'] + __sklearn_accs__

--- a/mindsdb_evaluator/accuracy/__init__.py
+++ b/mindsdb_evaluator/accuracy/__init__.py
@@ -1,3 +1,6 @@
+import importlib
+from sklearn.metrics import __all__ as __sklearn_accs__
+
 from mindsdb_evaluator.accuracy.general import evaluate_accuracy, evaluate_accuracies
 from mindsdb_evaluator.accuracy.regression import evaluate_regression_accuracy
 from mindsdb_evaluator.accuracy.classification import evaluate_multilabel_accuracy, evaluate_top_k_accuracy
@@ -7,12 +10,13 @@ from mindsdb_evaluator.accuracy.forecasting import \
     evaluate_cat_array_accuracy, \
     complementary_smape_array_accuracy
 
-from sklearn.metrics import __all__ as __sklearn_accs__
+
 __sklearn_accs__ = [acc for acc in __sklearn_accs__ if acc[0].lower() == acc[0]]
 
-# TODO: enable custom arg passing for sklearn metrics, also need to_ordinal and back, stateful?
+# TODO: enable custom arg passing for sklearn metrics, and to_ordinal (stateful?)
+sk_metrics = importlib.import_module('sklearn.metrics')
 for skacc in __sklearn_accs__:
-    exec(f'from sklearn.metrics import {skacc}')
+    globals()[skacc] = getattr(sk_metrics, skacc)
 
 __all__ = ['evaluate_accuracy', 'evaluate_accuracies', 'evaluate_regression_accuracy', 'evaluate_multilabel_accuracy',
            'evaluate_top_k_accuracy', 'evaluate_array_accuracy', 'evaluate_num_array_accuracy',

--- a/mindsdb_evaluator/accuracy/__init__.py
+++ b/mindsdb_evaluator/accuracy/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa  # otherwise F401 is triggered when adding all metrics from sklearn, even though no overwrites happen
 import importlib
 from sklearn.metrics import __all__ as __sklearn_accs__
 

--- a/mindsdb_evaluator/accuracy/__init__.py
+++ b/mindsdb_evaluator/accuracy/__init__.py
@@ -1,6 +1,7 @@
-# flake8: noqa  # otherwise F401 is triggered when adding all metrics from sklearn, even though no overwrites happen
-import importlib
-from sklearn.metrics import __all__ as __sklearn_accs__
+from sklearn.metrics import accuracy_score, auc, average_precision_score, balanced_accuracy_score, \
+    f1_score, mean_absolute_error, mean_squared_error, mean_squared_log_error, median_absolute_error, \
+    mean_absolute_percentage_error, precision_score, r2_score, recall_score, roc_auc_score, silhouette_score, \
+    top_k_accuracy_score
 
 from mindsdb_evaluator.accuracy.general import evaluate_accuracy, evaluate_accuracies
 from mindsdb_evaluator.accuracy.regression import evaluate_regression_accuracy
@@ -12,12 +13,33 @@ from mindsdb_evaluator.accuracy.forecasting import \
     complementary_smape_array_accuracy
 
 
-__sklearn_accs__ = [acc for acc in __sklearn_accs__ if acc[0].lower() == acc[0]]
+__all__ = [
+    # internal
+    'evaluate_accuracy',
+    'evaluate_accuracies',
+    'evaluate_regression_accuracy',
+    'evaluate_multilabel_accuracy',
+    'evaluate_top_k_accuracy',
+    'evaluate_array_accuracy',
+    'evaluate_num_array_accuracy',
+    'evaluate_cat_array_accuracy',
+    'complementary_smape_array_accuracy',
 
-sk_metrics = importlib.import_module('sklearn.metrics')
-for skacc in __sklearn_accs__:
-    globals()[skacc] = getattr(sk_metrics, skacc)
-
-__all__ = ['evaluate_accuracy', 'evaluate_accuracies', 'evaluate_regression_accuracy', 'evaluate_multilabel_accuracy',
-           'evaluate_top_k_accuracy', 'evaluate_array_accuracy', 'evaluate_num_array_accuracy',
-           'evaluate_cat_array_accuracy', 'complementary_smape_array_accuracy'] + __sklearn_accs__
+    # sklearn
+    'accuracy_score',
+    'auc',
+    'average_precision_score',
+    'balanced_accuracy_score',
+    'f1_score',
+    'mean_absolute_error',
+    'mean_squared_error',
+    'mean_squared_log_error',
+    'median_absolute_error',
+    'mean_absolute_percentage_error',
+    'precision_score',
+    'r2_score',
+    'recall_score',
+    'roc_auc_score',
+    'silhouette_score',
+    'top_k_accuracy_score'
+]

--- a/mindsdb_evaluator/accuracy/__init__.py
+++ b/mindsdb_evaluator/accuracy/__init__.py
@@ -7,6 +7,13 @@ from mindsdb_evaluator.accuracy.forecasting import \
     evaluate_cat_array_accuracy, \
     complementary_smape_array_accuracy
 
+from sklearn.metrics import __all__ as __sklearn_accs__
+__sklearn_accs__ = [acc for acc in __sklearn_accs__ if acc[0].lower() == acc[0]]
+
+# TODO: enable custom arg passing for sklearn metrics, also need to_ordinal and back, stateful?
+for skacc in __sklearn_accs__:
+    exec(f'from sklearn.metrics import {skacc}')
+
 __all__ = ['evaluate_accuracy', 'evaluate_accuracies', 'evaluate_regression_accuracy', 'evaluate_multilabel_accuracy',
            'evaluate_top_k_accuracy', 'evaluate_array_accuracy', 'evaluate_num_array_accuracy',
-           'evaluate_cat_array_accuracy', 'complementary_smape_array_accuracy']  # noqa
+           'evaluate_cat_array_accuracy', 'complementary_smape_array_accuracy'] + __sklearn_accs__  # noqa

--- a/mindsdb_evaluator/accuracy/general.py
+++ b/mindsdb_evaluator/accuracy/general.py
@@ -3,6 +3,7 @@ from typing import List, Dict, Optional, Union
 
 import numpy as np
 import pandas as pd
+from sklearn.preprocessing import LabelEncoder
 
 from mindsdb_evaluator.helpers.general import Module, filter_fn_args
 from mindsdb_evaluator.accuracy.forecasting import \
@@ -95,7 +96,15 @@ def evaluate_accuracies(data: pd.DataFrame,
                         target: str,
                         accuracy_functions: List[Union[str, Module]],
                         ts_analysis: Optional[dict] = {},
+                        labels: Optional[list] = [],
                         n_decimals: Optional[int] = 3) -> Dict[str, float]:
+    # if a label list is provided, we need to encode the target and predictions accordingly
+    if labels:
+        le = LabelEncoder()
+        le.fit(labels)
+        data[target] = le.transform(data[target])
+        predictions = le.transform(predictions)
+
     score_dict = {}
     for accuracy_function in accuracy_functions:
         fn_kwargs = {}

--- a/mindsdb_evaluator/accuracy/general.py
+++ b/mindsdb_evaluator/accuracy/general.py
@@ -80,7 +80,7 @@ def evaluate_accuracy(data: pd.DataFrame,
             assert type(score) in SCORE_TYPES, f"Accuracy function `{accuracy_function.__name__}` returned invalid type {type(score)}"  # noqa
         except ValueError as e:
             if 'mix of label input' in str(e).lower():
-                # mixed types, try to convert to string  # TODO: should this be a burden on the evaluator? No, shouldn't
+                # mixed types, try to convert to string. note: shouldn't happen anymore when labels are passed
                 fn_kwargs = filter_fn_args(accuracy_function, fn_kwargs)
                 score = accuracy_function([str(y) for y in y_true],
                                           [str(y) for y in y_pred],

--- a/mindsdb_evaluator/accuracy/general.py
+++ b/mindsdb_evaluator/accuracy/general.py
@@ -69,10 +69,9 @@ def evaluate_accuracy(data: pd.DataFrame,
         y_true = data[target].tolist()
         y_pred = list(predictions)
         if hasattr(importlib.import_module('mindsdb_evaluator.accuracy'), accuracy_function):
-            accuracy_function = getattr(importlib.import_module('mindsdb_evaluator.accuracy'),
-                                        accuracy_function)
+            accuracy_function = getattr(importlib.import_module('mindsdb_evaluator.accuracy'), accuracy_function)
         else:
-            accuracy_function = getattr(importlib.import_module('sklearn.metrics'), accuracy_function)
+            raise Exception(f"Could not retrieve accuracy function: {accuracy_function}")
 
         try:
             fn_kwargs = filter_fn_args(accuracy_function, fn_kwargs)
@@ -80,7 +79,7 @@ def evaluate_accuracy(data: pd.DataFrame,
             assert type(score) in SCORE_TYPES, f"Accuracy function `{accuracy_function.__name__}` returned invalid type {type(score)}"  # noqa
         except ValueError as e:
             if 'mix of label input' in str(e).lower():
-                # mixed types, try to convert to string  # TODO: should this be a burden on the evaluator?
+                # mixed types, try to convert to string  # TODO: should this be a burden on the evaluator? No, shouldn't
                 fn_kwargs = filter_fn_args(accuracy_function, fn_kwargs)
                 score = accuracy_function([str(y) for y in y_true],
                                           [str(y) for y in y_pred],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mindsdb-evaluator"
-version = "0.0.11"
+version = "0.0.12"
 description = "Model evaluation for Machine Learning pipelines."
 authors = ["MindsDB Inc. <hello@mindsdb.com>"]
 license = "GPL-3.0"


### PR DESCRIPTION
This PR is related to [Lightwood#1206](https://github.com/mindsdb/lightwood/pull/1206). Changes are:

- Moved `sklearn.metrics` imports from being dynamic within a module to static in the module initialization
- Added a label encoder so that the evaluator can handle string labels, provided a list of expected categories is passed when calling.