### PR TITLE
[fix] Optional RAG metrics

### DIFF
--- a/mindsdb_evaluator/__init__.py
+++ b/mindsdb_evaluator/__init__.py
@@ -1,7 +1,7 @@
 from mindsdb_evaluator.accuracy import *  # noqa
 from mindsdb_evaluator.calibration import *  # noqa
 
-__version__ = '0.0.14'
+__version__ = '0.0.15'
 name = "mindsdb_evaluator"
 
 __all__ = ['name', '__version__']

--- a/mindsdb_evaluator/accuracy/llm_generation.py
+++ b/mindsdb_evaluator/accuracy/llm_generation.py
@@ -1,13 +1,5 @@
 import numpy as np
 import pandas as pd
-from datasets import Dataset, Features, Sequence, Value
-from ragas import evaluate
-from ragas.metrics import (
-    faithfulness,
-    answer_relevancy,
-    context_precision,
-    context_recall
-)
 
 
 def _setup_rag_eval(data: pd.DataFrame, predictions: pd.Series) -> dict:
@@ -31,6 +23,18 @@ def evaluate_rag(metric: str,
     param fields: contains the input fields for RAGAS
     return: score
     """
+    try:
+        # ugly workaround, see `pyproject.toml` for why
+        from datasets import Dataset, Features, Sequence, Value
+        from ragas import evaluate
+        from ragas.metrics import (
+            faithfulness,
+            answer_relevancy,
+            context_precision,
+            context_recall
+        )
+    except Exception:
+        raise Exception("Dependencies for RAG metrics are not available. Re-install using `pip install mindsdb-evaluator[rag] and try again.")  # noqa
 
     new_context = [[str(entry)] for entry in [fields['contexts']]]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mindsdb-evaluator"
-version = "0.0.14"
+version = "0.0.15"
 description = "Model evaluation for Machine Learning pipelines."
 authors = ["MindsDB Inc. <hello@mindsdb.com>"]
 license = "GPL-3.0"
@@ -14,10 +14,16 @@ numpy = "^1"
 pandas = "^2"
 scikit-learn = ">=1.0"
 dataprep-ml = ">=0.0.17"
-datasets = "^2.20.0"
-ragas = "^0.1.13"  # see note about version at the bottom of this file
-pytest = "^8.3.2"
 
+# dependencies for optional packages
+datasets = {version = "^2.20.0", optional = true}
+ragas = {version = "^0.1.13", optional = true}    # see note about this at the bottom of this file
+
+[tool.poetry.extras]
+rag = [
+    "ragas",
+    "datasets",
+]
 
 [build-system]
 requires = ["poetry-core"]
@@ -28,9 +34,11 @@ build-backend = "poetry.core.masonry.api"
 # RAGAS requires `langchain-openai`, which asks for python>=3.8.1
 # this means when doing `poetry lock`, it will fail due to the >= 3.8 constraint
 # poetry has no easy fix for this (see poetry issue #697)
-# we have discussed internally that we'd rather do the following workaround for now:
+# the following workaround is useful:
 #   1. temporally bump mindsdb_evaluator in version range to `>=3.8.1,<3.12`
 #   2. generate `poetry.lock` file via `poetry lock`
 #   3. undo the version range bump to the original: `>=3.8,<3.12`
-#   4. push, everything works as normal (3.8.0 is not really used anywhere,
-#      but we'd rather keep as is for now instead of updating all our libraries)
+#   4. push, everything works as normal (3.8.0 is not really used anywhere)
+# However, we have discussed internally that we'd rather keep RAGAS optional for now
+# while we deprecate 3.8 support in our broader ecosystem. Once that happens, we can
+# bump this library to >=3.9 and move `rag` dependencies into core list.

--- a/tests/test_llm_accs.py
+++ b/tests/test_llm_accs.py
@@ -6,8 +6,8 @@ from mindsdb_evaluator.accuracy.llm_generation import evaluate_rag
 
 
 class TestLLM(unittest.TestCase):
-    # @unittest.skipIf(importlib.util.find_spec('ragas') is None, "`ragas` is not available, skipping RAG tests.")
-    # @unittest.skipIf(os.environ.get('OPENAI_API_KEY') is None, reason='Missing API key!')
+    @unittest.skipIf(importlib.util.find_spec('ragas') is None, "`ragas` is not available, skipping RAG tests.")
+    @unittest.skipIf(os.environ.get('OPENAI_API_KEY') is None, reason='Missing API key!')
     def test_evaluate_rag(self):
         data = {
             'question': 'What is the capital of France?',

--- a/tests/test_llm_accs.py
+++ b/tests/test_llm_accs.py
@@ -1,3 +1,4 @@
+import importlib
 import unittest
 import os
 
@@ -5,7 +6,8 @@ from mindsdb_evaluator.accuracy.llm_generation import evaluate_rag
 
 
 class TestLLM(unittest.TestCase):
-    @unittest.skipIf(os.environ.get('OPENAI_API_KEY') is None, reason='Missing API key!')
+    # @unittest.skipIf(importlib.util.find_spec('ragas') is None, "`ragas` is not available, skipping RAG tests.")
+    # @unittest.skipIf(os.environ.get('OPENAI_API_KEY') is None, reason='Missing API key!')
     def test_evaluate_rag(self):
         data = {
             'question': 'What is the capital of France?',


### PR DESCRIPTION
- Changes RAG dependencies to be optional for now, due to dependency issues (`ragas` depends on `langchain-openai` which needs `python>=3.8.1`). Once the rest of our packages deprecate support for `3.8` (@ZoranPandovski @dusvyat) we can bring these dependencies back to core.